### PR TITLE
Port to 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,17 @@
 org.gradle.jvmargs=-Xmx4G
 
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.3
-loader_version=0.14.11
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.1
+loader_version=0.14.17
 
 #Fabric api
-fabric_version=0.69.0+1.19.3
+fabric_version=0.75.3+1.19.4
 
 #Dependencies
-kyrptconfig=1.5.1-1.19.3
+kyrptconfig=1.5.2-1.19.4
 
 # Mod Properties
-mod_version=1.6.0-1.19.3
+mod_version=1.6.1-1.19.4
 maven_group=net.kyrptonaught
 archives_base_name=cmdkeybind
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "cmdkeybind",
-  "version": "1.6.0-1.19.3",
+  "version": "1.6.1-1.19.4",
   "name": "Command Macros",
   "description": "Command Macros!",
   "authors": [
@@ -23,7 +23,7 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.12.8",
+    "fabricloader": ">=0.14.17",
     "fabric": "*",
     "java": ">=17"
   }


### PR DESCRIPTION
This PR updates the plugin to work on 1.19.4 by upgrading the dependencies including kyrptconfig.

I've also bumped the plugin version to `1.6.1-1.19.4` with this change respectively.

Tested this with Quilt Loader 0.18.5 and encountered no problems.